### PR TITLE
Add switches that enable macOS compilation

### DIFF
--- a/src/argp-getopt.h
+++ b/src/argp-getopt.h
@@ -176,7 +176,11 @@ extern int __posix_getopt (int ___argc, char *const *___argv,
 #  endif
 # endif
 #else /* not __GNU_LIBRARY__ */
+#if __APPLE__
+extern int getopt (int argc, char *const *argv, const char *optstring);
+#else
 extern int getopt ();
+#endif
 #endif /* __GNU_LIBRARY__ */
 
 #ifndef __need_getopt

--- a/src/argp-help.c
+++ b/src/argp-help.c
@@ -1749,7 +1749,7 @@ __argp_state_help (const struct argp_state *state, FILE *stream, unsigned flags)
 #ifdef weak_alias
 weak_alias (__argp_state_help, argp_state_help)
 #endif
-
+
 /* If appropriate, print the printf string FMT and following args, preceded
    by the program name and `:', to stderr, and followed by a `Try ... --help'
    message, then exit (1).  */

--- a/src/argp-help.c
+++ b/src/argp-help.c
@@ -1873,8 +1873,8 @@ __argp_failure (const struct argp_state *state, int status, int errnum,
 	      putc_unlocked (' ', stream);
 # if defined(HAVE_STRERROR_R) && HAVE_STRERROR_R
 #if __APPLE__
-        (void) __strerror_r (errnum, buf, sizeof (buf));
-        fputs (buf, stream);
+	      (void) __strerror_r (errnum, buf, sizeof (buf));
+	      fputs (buf, stream);
 #else	      
 	      fputs (__strerror_r (errnum, buf, sizeof (buf)), stream);
 #endif

--- a/src/argp-help.c
+++ b/src/argp-help.c
@@ -1749,7 +1749,7 @@ __argp_state_help (const struct argp_state *state, FILE *stream, unsigned flags)
 #ifdef weak_alias
 weak_alias (__argp_state_help, argp_state_help)
 #endif
-
+
 /* If appropriate, print the printf string FMT and following args, preceded
    by the program name and `:', to stderr, and followed by a `Try ... --help'
    message, then exit (1).  */
@@ -1872,7 +1872,12 @@ __argp_failure (const struct argp_state *state, int status, int errnum,
 	      putc_unlocked (':', stream);
 	      putc_unlocked (' ', stream);
 # if defined(HAVE_STRERROR_R) && HAVE_STRERROR_R
-	      fputs (__strerror_r (errnum, buf, sizeof (buf)), stream);
+#if __APPLE__
+        (void) __strerror_r (errnum, buf, sizeof (buf));
+        fputs (buf, stream);
+#else	      
+      fputs (__strerror_r (errnum, buf, sizeof (buf)), stream);
+#endif
 # else
 	      fputs (strerror (errnum), stream);
 # endif

--- a/src/argp-help.c
+++ b/src/argp-help.c
@@ -1876,7 +1876,7 @@ __argp_failure (const struct argp_state *state, int status, int errnum,
         (void) __strerror_r (errnum, buf, sizeof (buf));
         fputs (buf, stream);
 #else	      
-      fputs (__strerror_r (errnum, buf, sizeof (buf)), stream);
+	      fputs (__strerror_r (errnum, buf, sizeof (buf)), stream);
 #endif
 # else
 	      fputs (strerror (errnum), stream);

--- a/src/argp-parse.c
+++ b/src/argp-parse.c
@@ -49,7 +49,6 @@ char *alloca ();
 #include <stdlib.h>
 #include <string.h>
 #if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H
-
 # include <unistd.h>
 #endif
 #include <limits.h>

--- a/src/argp-parse.c
+++ b/src/argp-parse.c
@@ -49,11 +49,8 @@ char *alloca ();
 #include <stdlib.h>
 #include <string.h>
 #if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H
-#if __APPLE__
-unsigned int sleep(unsigned int seconds);
-#else
+
 # include <unistd.h>
-#endif
 #endif
 #include <limits.h>
 #include "argp-getopt.h"

--- a/src/argp-parse.c
+++ b/src/argp-parse.c
@@ -49,7 +49,11 @@ char *alloca ();
 #include <stdlib.h>
 #include <string.h>
 #if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H
+#if __APPLE__
+unsigned int sleep(unsigned int seconds);
+#else
 # include <unistd.h>
+#endif
 #endif
 #include <limits.h>
 #include "argp-getopt.h"


### PR DESCRIPTION
The standalone build fails on macOS with C23. This PR introduces minimal changes that rely on `__APPLE__` preprocessor variable available on macOS to turn fix compilation warnings and errors.

Tested on macbook m4 pro, macOs Tahoe Version 26.4.1 (25E253). I don't have access to any other device.