### PR TITLE
Fix mess with getopt prototypes in argp-getopt.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2020 Thomas Mathys
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# argp-standalone: standalone version of glibc's argp functions.
+# argp-standalone - standalone version of glibc's argp functions.
 
 cmake_minimum_required(VERSION 3.17.3)
 project(argp-standalone VERSION 1.0.3 LANGUAGES C)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2020 Thomas Mathys
 SPDX-License-Identifier: LGPL-2.1-or-later
-argp-standalone: standalone version of glibc's argp functions.
+argp-standalone - standalone version of glibc's argp functions.
 -->
 
 # argp-standalone

--- a/cmake/ArgpStandaloneEnableWarnings.cmake
+++ b/cmake/ArgpStandaloneEnableWarnings.cmake
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Thomas Mathys
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# argp-standalone: standalone version of glibc's argp functions.
+# argp-standalone - standalone version of glibc's argp functions.
 
 function(argp_standalone_target_enable_warnings target)
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2020 Thomas Mathys
  * SPDX-License-Identifier: LGPL-2.1-or-later
- * argp-standalone: standalone version of glibc's argp functions.
+ * argp-standalone - standalone version of glibc's argp functions.
  */
 
 /* Headers */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2020 Thomas Mathys
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# argp-standalone: standalone version of glibc's argp functions.
+# argp-standalone - standalone version of glibc's argp functions.
 
 set(
   SOURCES

--- a/src/argp-compat.c
+++ b/src/argp-compat.c
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2020 Thomas Mathys
  * SPDX-License-Identifier: LGPL-2.1-or-later
- * argp-standalone: standalone version of glibc's argp functions.
+ * argp-standalone - standalone version of glibc's argp functions.
  */
 
 #include <string.h>

--- a/src/argp-compat.h
+++ b/src/argp-compat.h
@@ -1,7 +1,7 @@
 /*
  * SPDX-FileCopyrightText: 2020 Thomas Mathys
  * SPDX-License-Identifier: LGPL-2.1-or-later
- * argp-standalone: standalone version of glibc's argp functions.
+ * argp-standalone - standalone version of glibc's argp functions.
  */
 
 #ifndef ARGP_COMPAT_H_INCLUDED

--- a/src/argp-getopt.h
+++ b/src/argp-getopt.h
@@ -176,11 +176,13 @@ extern int __posix_getopt (int ___argc, char *const *___argv,
 #  endif
 # endif
 #else /* not __GNU_LIBRARY__ */
-# if __APPLE__ && __MACH__
-extern int getopt (int argc, char *const *argv, const char *optstring);
-# else
-extern int getopt ();
-# endif
+/*
+ * The following declaration may conflict with the declaration from unistd.h.
+ * Since getopt itself compiles without this declaration and argp-standalone
+ * only provides argp but not getopt to its clients we simply remove this
+ * declaration.
+ */
+/* extern int getopt (); */
 #endif /* __GNU_LIBRARY__ */
 
 #ifndef __need_getopt

--- a/src/argp-getopt.h
+++ b/src/argp-getopt.h
@@ -182,7 +182,9 @@ extern int __posix_getopt (int ___argc, char *const *___argv,
  * only provides argp but not getopt to its clients we simply remove this
  * declaration.
  */
-/* extern int getopt (); */
+# if 0
+extern int getopt ();
+# endif
 #endif /* __GNU_LIBRARY__ */
 
 #ifndef __need_getopt

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2020 Thomas Mathys
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# argp-standalone: standalone version of glibc's argp functions.
+# argp-standalone - standalone version of glibc's argp functions.
 
 add_executable(argp-test argp-test.c)
 target_compile_definitions(argp-test PRIVATE HAVE_CONFIG_H)


### PR DESCRIPTION
argp-getopt.h has declarations for getopt that may conflict with what the target system might have in unistd.h.
We do not need these declarations ourselves nor do we provide them to client code, so rather than patching them whenever
we encounter a target we have not yet covered we simply remove them.